### PR TITLE
Update doc links for ACM 2.4

### DIFF
--- a/quick_start.adoc
+++ b/quick_start.adoc
@@ -30,18 +30,18 @@ We will first walk through setting up your managed cluster set and placement, th
 In order to add managed clusters to a managed cluster set, the managed clusters must be under management of the hub cluster.
 Follow these instructions if managed clusters need to be brought under management by the hub cluster:
 
-* Red Hat Advanced Cluster Management - https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.3/html/clusters/importing-a-target-managed-cluster-to-the-hub-cluster[Importing a target managed cluster to the hub cluster]
+* Red Hat Advanced Cluster Management - https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.4/html/clusters/importing-a-target-managed-cluster-to-the-hub-cluster[Importing a target managed cluster to the hub cluster]
 * Red Hat multicluster engine operator - https://open-cluster-management.github.io/mce-docs/quick_start.html#getting-started[Importing a target managed cluster to the hub cluster]
 
 Once there are managed clusters, create a managed cluster set and managedclustersetbinding.  Then select the
 managed clusters that will be a part of the set:
 
-* Red Hat Advanced Cluster Management - https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.3/html/clusters/managedclustersets#placement-managed[creating and managing managedclustersets]
+* Red Hat Advanced Cluster Management - https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.4/html/clusters/managedclustersets#placement-managed[creating and managing managedclustersets]
 * Red Hat multicluster engine operator - https://open-cluster-management.github.io/mce-docs/quick_start.html#getting-started[creating and managing managedclustersets]
 
 Now a placement can be created.  This will be used to determine which managed clusters in the managedclusterset will have the identity configuration applied.  See:
 
-* Red Hat Advanced Cluster Management - https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.3/html/clusters/managedclustersets#placement-managed[using managedclustersets with placement]
+* Red Hat Advanced Cluster Management - https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.4/html/clusters/managedclustersets#placement-managed[using managedclustersets with placement]
 * Red Hat multicluster engine operator - https://open-cluster-management.github.io/mce-docs/quick_start.html#getting-started[creating and managing managedclustersets]
 
 


### PR DESCRIPTION
Update doc links for ACM 2.4. Currently 404 but will be live once 2.4 is released.