### PR TITLE
update note about cluster detach

### DIFF
--- a/quick_start.adoc
+++ b/quick_start.adoc
@@ -52,7 +52,7 @@ The identity configuration management for Kubernetes Technology Preview does not
 
 [IMPORTANT]
 ====
-Before detaching cluster from hub, you will need to make sure managedcluster is no longer managed by identity configuration management. You can remove cluster from identity provider managegment either by removing cluster from matching placement or removing cluster from ManageClusterSet. You can remove cluster from matching placement by removing labels. If the cluster detached without being unmanaged from identity provider management, you will loose access to the cluster. 
+Before detaching a cluster from the hub, you will need to make sure the managed cluster is no longer managed by identity configuration management. You can remove the cluster from identity configuration management either by removing the cluster from the ManagedClusterSet, or by removing labels from the managed cluster as appropriate to no longer match the Placement. If the cluster is detached without first being unmanaged from identity provider management, you will lose access to the cluster.
 ====
 
 

--- a/quick_start.adoc
+++ b/quick_start.adoc
@@ -47,7 +47,12 @@ Now a placement can be created.  This will be used to determine which managed cl
 
 [IMPORTANT]
 ====
-The identity configuration management for Kubernetes Technology Preview does not yet utilize custom role definitions for controlling access to work with AuthRealms. Instead, it relies on the role-based access control implemented by multicluster engine and Advanced Cluster Management around ManagedClusterSets, ManagedClusterSetBindings, and Placements. AuthRealms must exist in a namespace containing a Placement, and the Placement leverages the ManagedClusterSets that are bound to that namespace. Access to namespaces with existing bound ManagedClusterSets and/or existing Placements should be managed accordingly.
+The identity configuration management for Kubernetes Technology Preview does not yet utilize custom role definitions for controlling access to work with AuthRealms. Instead, it relies on the role-based access control implemented by multicluster engine and Advanced Cluster Management around ManagedClusterSets, ManagedClusterSetBindings, and Placements. AuthRealms must exist in a namespace containing a Placement, and the Placement leverages the ManagedClusterSets that are bound to that namespace. Access to namespaces with existing bound ManagedClusterSets and/or existing Placements should be managed accordingly. 
+====
+
+[IMPORTANT]
+====
+Before detaching cluster from hub, you will need to make sure managedcluster is no longer managed by identity configuration management. You can remove cluster from identity provider managegment either by removing cluster from matching placement or removing cluster from ManageClusterSet. You can remove cluster from matching placement by removing labels. If the cluster detached without being unmanaged from identity provider management, you will loose access to the cluster. 
 ====
 
 


### PR DESCRIPTION
Signed-off-by: Leena Jawale <ljawale@redhat.com>

Managedcluster should be unmanaged from identity provider mnagement before detaching cluster to avoid invalid OAuth because of client secret deletion on the mangedcluster 